### PR TITLE
pg_tracing: spans ring logic

### DIFF
--- a/contrib/pg_tracing/expected/select_big.out
+++ b/contrib/pg_tracing/expected/select_big.out
@@ -1,0 +1,167 @@
+CREATE EXTENSION pg_tracing;
+ERROR:  extension "pg_tracing" already exists
+SELECT pg_tracing_reset();
+ pg_tracing_reset 
+------------------
+ 
+(1 row)
+
+SELECT traces from pg_tracing_info;
+ traces 
+--------
+      0
+(1 row)
+
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+ ?column? 
+----------
+        1
+(1 row)
+
+SELECT trace_id, parent_id, resource from pg_tracing_spans;
+      trace_id       |      parent_id      |   resource    
+---------------------+---------------------+---------------
+ 9138813148648157906 | 9138813148648157906 | ExecutorStart
+ 9138813148648157906 | 9138813148648157906 | ExecutorStart
+ 9138813148648157906 | 9138813148648157906 | ExecutorStart
+ 9138813148648157906 | 9138813148648157906 | ExecutorStart
+ 9138813148648157906 | 9138813148648157906 | ExecutorStart
+ 9138813148648157906 | 9138813148648157906 | ExecutorStart
+ 9138813148648157906 | 9138813148648157906 | ExecutorStart
+ 9138813148648157906 | 9138813148648157906 | ExecutorStart
+ 9138813148648157906 | 9138813148648157906 | ExecutorStart
+ 9138813148648157906 | 9138813148648157906 | ExecutorStart
+ 9138813148648157906 | 9138813148648157906 | ExecutorStart
+ 9138813148648157906 | 9138813148648157906 | ExecutorStart
+ 9138813148648157906 | 9138813148648157906 | ExecutorStart
+ 9138813148648157906 | 9138813148648157906 | ExecutorStart
+ 9138813148648157906 | 9138813148648157906 | ExecutorStart
+ 9138813148648157906 | 9138813148648157906 | ExecutorStart
+ 9138813148648157906 | 9138813148648157906 | ExecutorStart
+ 9138813148648157906 | 9138813148648157906 | ExecutorStart
+ 9138813148648157906 | 9138813148648157906 | ExecutorStart
+ 9138813148648157906 | 9138813148648157906 | ExecutorStart
+ 9138813148648157906 | 9138813148648157906 | ExecutorStart
+ 9138813148648157906 | 9138813148648157906 | ExecutorStart
+(22 rows)
+

--- a/contrib/pg_tracing/meson.build
+++ b/contrib/pg_tracing/meson.build
@@ -28,7 +28,8 @@ tests += {
   'bd': meson.current_build_dir(),
   'regress': {
 	'sql': [
-	  'select'
+	  'select',
+      'select_big'
     ],
 	'regress_args': ['--temp-config', files('pg_tracing.conf')],
   },

--- a/contrib/pg_tracing/sql/select_big.sql
+++ b/contrib/pg_tracing/sql/select_big.sql
@@ -1,0 +1,28 @@
+CREATE EXTENSION pg_tracing;
+SELECT pg_tracing_reset();
+
+
+SELECT traces from pg_tracing_info;
+
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+/*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+SELECT trace_id, parent_id, resource from pg_tracing_spans;

--- a/contrib/pg_tracing/sql/select_big.sql
+++ b/contrib/pg_tracing/sql/select_big.sql
@@ -25,4 +25,5 @@ SELECT traces from pg_tracing_info;
 /*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
 /*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
 /*dddbs='postgres.db',traceparent='00-00000000000000007ed39623a1d7b2d2-7ed39623a1d7b2d2-01'*/ SELECT 1;
+
 SELECT trace_id, parent_id, resource from pg_tracing_spans;


### PR DESCRIPTION
Add a ring logic if the number of spans is higher than the static limit.
The ``spans`` attribute of ``pgTracingGlobalStats`` register the total amount of spans. Meaning that if the maximum is set at 10 spans and 15 spans are found, ``spans`` will be equal to 15 and ``pg_tracing_spans`` will output 10 spans